### PR TITLE
fix(handler): fails to serve requests

### DIFF
--- a/src/packages/lemonldap-ng-handler/lib/index.coffee
+++ b/src/packages/lemonldap-ng-handler/lib/index.coffee
@@ -4,6 +4,8 @@
 # See README.md for license and copyright
 ###
 conf = null
+normalizeUrl = require 'normalize-url'
+urlParse = require('url').parse
 
 class Handler
 	constructor: (args) ->
@@ -15,7 +17,8 @@ class Handler
 	run: (req, res, next) ->
 		self = @
 		vhost = req.headers.host
-		uri = decodeURI req.url
+		normalizedUrl = normalizeUrl (vhost + req.url)
+		uri = urlParse(normalizedUrl).path
 		if @conf.tsv.maintenance[vhost]
 			self.logger.info "Go to portal with maintenance error code #{vhost}"
 			return @setError res, '/', 503, 'Service Temporarily Unavailable'

--- a/src/packages/lemonldap-ng-handler/lib/index.coffee
+++ b/src/packages/lemonldap-ng-handler/lib/index.coffee
@@ -4,7 +4,6 @@
 # See README.md for license and copyright
 ###
 conf = null
-normalizeUrl = require 'normalize-url'
 
 class Handler
 	constructor: (args) ->
@@ -16,7 +15,7 @@ class Handler
 	run: (req, res, next) ->
 		self = @
 		vhost = req.headers.host
-		uri = normalizeUrl req.url
+		uri = decodeURI req.url
 		if @conf.tsv.maintenance[vhost]
 			self.logger.info "Go to portal with maintenance error code #{vhost}"
 			return @setError res, '/', 503, 'Service Temporarily Unavailable'


### PR DESCRIPTION
normalize-url returns with `TypeError [ERR_INVALID_URL]`.
`req.url`, in expressjs or nodejs/http context, is the path called,
rather than a full URL.

Also:
https://github.com/LemonLDAPNG/node-lemonldap-ng-handler/blob/136aa83ed431462fa42ce17b7f9b24e056de06be/src/lib/index.coffee#L48

Assuming the normalize-url would have worked, this would generate
a broken URL, with two sets of proto+hosts