### PR TITLE
feat(ldaps): custom CA support

### DIFF
--- a/src/packages/lemonldap-ng-conf-ldap/lib/index.coffee
+++ b/src/packages/lemonldap-ng-conf-ldap/lib/index.coffee
@@ -11,6 +11,7 @@ class ldapConf
 			unless args[a]
 				throw "Missing #{a} argument"
 		@ldapServer = if args.ldapServer.match(/^ldap/) then args.ldapServer else "ldap://#{args.ldapServer}"
+		@ldapCa = if args.ldapServer.match(/^ldaps/) then (args.ldapCAFile or '') else ''
 		@ldapConfBase = args.ldapConfBase
 		@dn = args.ldapBindDN
 		@pwd = args.ldapBindPassword
@@ -18,7 +19,14 @@ class ldapConf
 		@idAttr   = args.ldapAttributeId or 'cn'
 		@contentAttr = args.ldapAttributeContent or 'description'
 		@base = args.ldapConfBase
+		@caConf = {}
+		if @ldapCa != ''
+			try
+				caData = require('fs').readFileSync(@ldapCa)
+				@caConf = { ca: [ caData ] }
+			catch caError
 		@ldap = require('ldapjs').createClient
+			tlsOptions: @caConf
 			url: @ldapServer
 
 	available: ->

--- a/src/packages/lemonldap-ng-session-ldap/lib/index.coffee
+++ b/src/packages/lemonldap-ng-session-ldap/lib/index.coffee
@@ -11,6 +11,7 @@ class LdapSession
 			unless args[a]
 				throw "Missing #{a} argument"
 		@ldapServer = if args.ldapServer.match(/^ldap/) then args.ldapServer else "ldap://#{args.ldapServer}"
+		@ldapCa = if args.ldapServer.match(/^ldaps/) then (args.ldapCAFile or '') else ''
 		@ldapConfBase = args.ldapConfBase
 		@dn = args.ldapBindDN
 		@pwd = args.ldapBindPassword
@@ -18,8 +19,15 @@ class LdapSession
 		@idAttr   = args.ldapAttributeId or 'cn'
 		@contentAttr = args.ldapAttributeContent or 'description'
 		@base = args.ldapConfBase
+		@caConf = {}
+		if @ldapCa != ''
+			try
+				caData = require('fs').readFileSync(@ldapCa)
+				@caConf = { ca: [ caData ] }
+			catch caError
 		L = require 'ldapjs'
 		@ldap = require('ldapjs').createClient
+			tlsOptions: @caConf
 			url: @ldapServer
 		self = @
 		@ldap.bind @dn, @pwd, (err) ->


### PR DESCRIPTION
both https://lemonldap-ng.org/documentation/latest/ldapsessionbackend.html
and https://lemonldap-ng.org/documentation/latest/ldapconfbackend.html
would suggest lemonldap-ng.ini (and wherever the sessions configuration
is stored) may include some `ldapCAFile` and `ldapCAPath` options.

On the other hand,
https://lemonldap-ng.org/documentation/latest/parameterlist suggests
those couple option only apply to the portal -- not to the handler (?)

Regardless:

- node-ldapjs uses NodeJS TLS defaults
(https://github.com/ldapjs/node-ldapjs/blob/master/docs/client.md)

- NodeJS doesn't use OS trusted certificates.
(https://nodejs.org/api/tls.html#tls_tls_rootcertificates)

Using a custom PKI, although it would be possible to set some
`NODE_TLS_REJECT_UNAUTHORIZED` environment variable, disabling TLS
verification in NodeJS: it would be better to load some user-defined
chain of trust.

Current commit implements support for `ldapCAFile`.